### PR TITLE
chore: Several changes

### DIFF
--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -3,6 +3,15 @@
 ## folder as this file.
 
 version: "3.7"
+
+networks:
+  simulation:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.1.0.0/22"
+
 x-logging: &logging
   logging:
     driver: json-file
@@ -29,25 +38,28 @@ x-pg-exporter-env: &pg_exp_env
 
 services:
 
-  nwaku_client_postgres:
-    ## Waku node that acts as a Store client to the `nwaku_postgres` and listens
-    ## to REST-Store requests
+  bootstrap:
     image: statusteam/nim-waku:v0.20.0
     restart: on-failure
-    <<:
-      - *logging
-    volumes:
-      - ./run_nwaku_store_client_postgres.sh:/opt/run_nwaku_store_client_postgres.sh:Z
+    ports:
+      - 127.0.0.1:60000:60000
+      - 127.0.0.1:8008:8008
+      - 127.0.0.1:9000:9000
+      - 127.0.0.1:8544:8544
     entrypoint: sh
     command:
-      - /opt/run_nwaku_store_client_postgres.sh
-    depends_on:
-      - nwaku_postgres
+    - '/opt/run_bootstrap.sh'
+    volumes:
+      - ./run_bootstrap.sh:/opt/run_bootstrap.sh:Z
+    networks:
+      - simulation
 
-  nwaku_sqlite:
+  nwaku-sqlite:
     ## Waku node with Store mounted & SQLite
     image: ubuntu
     restart: on-failure
+    ports:
+      - 0.0.0.0:8546:8546
     <<:
       - *logging
     volumes:
@@ -57,53 +69,60 @@ services:
     entrypoint: sh
     command:
       - /opt/run_nwaku_store_sqlite.sh
+    networks:
+      - simulation
 
-  nwaku_client_sqlite:
-    ## Waku node that acts as a Store client to the `nwaku_sqlite` and listens
-    ## to REST-Store requests
-    image: statusteam/nim-waku:v0.20.0
-    restart: on-failure
-    <<:
-      - *logging
-    volumes:
-      - ./run_nwaku_store_client_sqlite.sh:/opt/run_nwaku_store_client_sqlite.sh:Z
-    entrypoint: sh
-    command:
-      - /opt/run_nwaku_store_client_sqlite.sh
-    depends_on:
-      - nwaku_sqlite
-
-  nwaku_postgres:
+  nwaku-postgres:
     ## Waku node with Store mounted & Postgres
     image: ubuntu
     restart: on-failure
+    ports:
+      - 0.0.0.0:8545:8545
     <<:
       - *logging
       - *pg_env
     volumes:
     # This is expected to be run from metal-01.he-eu-hel1.wakudev.misc.statusim.net
-      - /home/shared/nwaku/build/wakunode2:/usr/bin/wakunode:Z
-      - ./run_nwaku_store_postgres_ubuntu.sh:/opt/run_nwaku_store_postgres.sh:Z
+      - /home/ivansete/workspace/status/nwaku/build/wakunode2:/usr/bin/wakunode:Z
+      - ./run_nwaku_store_postgres_ubuntu.sh:/opt/run_nwaku_store_postgres_ubuntu.sh:Z
     entrypoint: bash
     command:
-      - /opt/run_nwaku_store_postgres.sh
+      - /opt/run_nwaku_store_postgres_ubuntu.sh
     depends_on:
       - postgres
+    networks:
+      - simulation
 
-  # msg_publisher:
-  #   ## Sends json-rpc 'post_waku_v2_relay_v1_message' messages infinitely
-  #   image: alpine:3.16
-  #   restart: on-failure
-  #   logging:
-  #     driver: "none"
-  #   volumes:
-  #     - ./msg_publisher.sh:/opt/msg_publisher.sh:Z
-  #   entrypoint: sh
-  #   command:
-  #     - /opt/msg_publisher.sh
-  #   depends_on:
-  #     - nwaku_postgres
-  #     - nwaku_sqlite
+  waku-store-query-generator:
+    image: ivansete/waku-store-request-maker:91bb3ffd
+    restart: on-failure
+    entrypoint: sh
+      - 'opt/run_waku_store_query_maker.sh'
+    deploy:
+      replicas: 1
+    volumes:
+      - ./run_waku_store_query_maker.sh:/opt/run_waku_store_query_maker.sh:Z
+    environment:
+      STORE_QUERIES_PER_SECOND: 10
+    networks:
+      - simulation
+
+  waku-publisher:
+    image: alrevuelta/waku-publisher:9fb206c
+    entrypoint: sh
+      - 'opt/run_wakupublisher.sh'
+    deploy:
+      replicas: 1
+    volumes:
+      - ./run_wakupublisher.sh:/opt/run_wakupublisher.sh:Z
+    environment:
+      MSG_PER_SECOND: 10
+      MSG_SIZE_KBYTES: 10
+    depends_on:
+      - nwaku-postgres
+      - nwaku-sqlite
+    networks:
+      - simulation
 
   prometheus:
     image: docker.io/prom/prometheus:latest
@@ -114,11 +133,15 @@ services:
     restart: on-failure
     depends_on:
       - postgres-exporter
-      - nwaku_postgres
-      - nwaku_sqlite
+      - nwaku-postgres
+      - nwaku-sqlite
+    networks:
+      - simulation
 
   grafana:
     image: docker.io/grafana/grafana:latest
+    ports:
+      - 0.0.0.0:3000:3000
     env_file:
       - ./monitoring/configuration/grafana-plugins.env
     volumes:
@@ -132,12 +155,16 @@ services:
     restart: on-failure
     depends_on:
       - prometheus
+    networks:
+      - simulation
 
   postgres:
     # This service is used when the Waku node has the 'store' protocol enabled
     # and the store-message-db-url is set to use Postgres
     image: postgres:15.4-alpine3.18
     restart: on-failure
+    ports:
+      - 0.0.0.0:5432:5432
     <<: *pg_env
     volumes:
       - ./data/postgres-data:/var/lib/postgresql/data
@@ -150,6 +177,8 @@ services:
       timeout: 60s
       retries: 5
       start_period: 80s
+    networks:
+      - simulation
 
   postgres-exporter:
     # Service aimed to scrape information from Postgres and post it to Prometeus
@@ -164,3 +193,5 @@ services:
       - --config.file=/etc/pgexporter/postgres-exporter.yml
     depends_on:
       - postgres
+    networks:
+      - simulation

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -83,7 +83,7 @@ services:
       - *pg_env
     volumes:
     # This is expected to be run from metal-01.he-eu-hel1.wakudev.misc.statusim.net
-      - /home/ivansete/workspace/status/nwaku/build/wakunode2:/usr/bin/wakunode:Z
+      - /home/shared/nwaku/build/wakunode2:/usr/bin/wakunode:Z
       - ./run_nwaku_store_postgres_ubuntu.sh:/opt/run_nwaku_store_postgres_ubuntu.sh:Z
     entrypoint: bash
     command:

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -94,7 +94,7 @@ services:
       - simulation
 
   waku-store-query-generator:
-    image: ivansete/waku-store-request-maker:91bb3ffd
+    image: ivansete/waku-store-request-maker:19e645
     restart: on-failure
     entrypoint: sh
       - 'opt/run_waku_store_query_maker.sh'
@@ -103,7 +103,7 @@ services:
     volumes:
       - ./run_waku_store_query_maker.sh:/opt/run_waku_store_query_maker.sh:Z
     environment:
-      STORE_QUERIES_PER_SECOND: 10
+      STORE_QUERIES_PER_SECOND: 1
     networks:
       - simulation
 

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -51,6 +51,11 @@ services:
     - '/opt/run_bootstrap.sh'
     volumes:
       - ./run_bootstrap.sh:/opt/run_bootstrap.sh:Z
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2048M
     networks:
       - simulation
 
@@ -69,6 +74,11 @@ services:
     entrypoint: sh
     command:
       - /opt/run_nwaku_store_sqlite.sh
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2048M
     networks:
       - simulation
 
@@ -90,6 +100,11 @@ services:
       - /opt/run_nwaku_store_postgres_ubuntu.sh
     depends_on:
       - postgres
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2048M
     networks:
       - simulation
 
@@ -177,6 +192,11 @@ services:
       timeout: 60s
       retries: 5
       start_period: 80s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2048M
     networks:
       - simulation
 

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -65,6 +65,7 @@ services:
     restart: on-failure
     ports:
       - 0.0.0.0:8546:8546
+      - 0.0.0.0:8004:8004
     <<:
       - *logging
     volumes:
@@ -88,6 +89,7 @@ services:
     restart: on-failure
     ports:
       - 0.0.0.0:8545:8545
+      - 0.0.0.0:8003:8003
     <<:
       - *logging
       - *pg_env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     ## Waku node with Store mounted & Postgres
     image: statusteam/nim-waku:v0.20.0
     restart: on-failure
+    ports:
+      - 0.0.0.0:30303:30303
+      - 0.0.0.0:9000:9000
     <<:
       - *logging
       - *pg_env
@@ -60,8 +63,11 @@ services:
 
   nwaku_sqlite:
     ## Waku node with Store mounted & SQLite
-    image: statusteam/nim-waku:v0.19.0
+    image: statusteam/nim-waku:v0.20.0
     restart: on-failure
+    ports:
+      - 0.0.0.0:30304:30304
+      - 0.0.0.0:9001:9001
     <<:
       - *logging
     volumes:
@@ -74,7 +80,7 @@ services:
   nwaku_client_sqlite:
     ## Waku node that acts as a Store client to the `nwaku_sqlite` and listens
     ## to REST-Store requests
-    image: statusteam/nim-waku:v0.19.0
+    image: statusteam/nim-waku:v0.20.0
     restart: on-failure
     <<:
       - *logging
@@ -86,20 +92,20 @@ services:
     depends_on:
       - nwaku_sqlite
 
-  msg_publisher:
-    ## Sends json-rpc 'post_waku_v2_relay_v1_message' messages infinitely
-    image: alpine:3.16
-    restart: on-failure
-    logging:
-      driver: "none"
-    volumes:
-      - ./msg_publisher.sh:/opt/msg_publisher.sh:Z
-    entrypoint: sh
-    command:
-      - /opt/msg_publisher.sh
-    depends_on:
-      - nwaku_postgres
-      - nwaku_sqlite
+  # msg_publisher:
+  #   ## Sends json-rpc 'post_waku_v2_relay_v1_message' messages infinitely
+  #   image: alpine:3.16
+  #   restart: on-failure
+  #   logging:
+  #     driver: "none"
+  #   volumes:
+  #     - ./msg_publisher.sh:/opt/msg_publisher.sh:Z
+  #   entrypoint: sh
+  #   command:
+  #     - /opt/msg_publisher.sh
+  #   depends_on:
+  #     - nwaku_postgres
+  #     - nwaku_sqlite
 
   prometheus:
     image: docker.io/prom/prometheus:latest
@@ -126,6 +132,8 @@ services:
       - ./monitoring/configuration/customizations/custom-logo.svg:/usr/share/grafana/public/img/grafana_typelogo.svg:Z
       - ./monitoring/configuration/customizations/custom-logo.png:/usr/share/grafana/public/img/fav32.png:Z
     restart: on-failure
+    ports:
+      - 0.0.0.0:3000:3000
     depends_on:
       - prometheus
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -92,20 +92,20 @@ services:
     depends_on:
       - nwaku_sqlite
 
-  # msg_publisher:
-  #   ## Sends json-rpc 'post_waku_v2_relay_v1_message' messages infinitely
-  #   image: alpine:3.16
-  #   restart: on-failure
-  #   logging:
-  #     driver: "none"
-  #   volumes:
-  #     - ./msg_publisher.sh:/opt/msg_publisher.sh:Z
-  #   entrypoint: sh
-  #   command:
-  #     - /opt/msg_publisher.sh
-  #   depends_on:
-  #     - nwaku_postgres
-  #     - nwaku_sqlite
+  msg_publisher:
+    ## Sends json-rpc 'post_waku_v2_relay_v1_message' messages infinitely
+    image: alpine:3.16
+    restart: on-failure
+    logging:
+      driver: "none"
+    volumes:
+      - ./msg_publisher.sh:/opt/msg_publisher.sh:Z
+    entrypoint: sh
+    command:
+      - /opt/msg_publisher.sh
+    depends_on:
+      - nwaku_postgres
+      - nwaku_sqlite
 
   prometheus:
     image: docker.io/prom/prometheus:latest

--- a/docker/monitoring/configuration/dashboards/waku-analysis.json
+++ b/docker/monitoring/configuration/dashboards/waku-analysis.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 36,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -120,7 +119,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "targets": [
         {
           "datasource": {
@@ -186,7 +185,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "targets": [
         {
           "datasource": {
@@ -228,6 +227,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -326,6 +326,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -424,6 +425,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -446,7 +448,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -545,6 +548,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -566,7 +570,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -666,6 +671,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -687,7 +693,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -757,6 +764,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "stepBefore",
             "lineStyle": {
               "fill": "solid"
@@ -781,7 +789,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -881,6 +890,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -902,7 +912,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -972,6 +983,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -993,7 +1005,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1063,6 +1076,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1084,7 +1098,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1197,7 +1212,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1292,7 +1307,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1387,7 +1402,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1508,7 +1523,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1603,7 +1618,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1725,7 +1740,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1782,7 +1797,6 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1795,13 +1809,14 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 4,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1823,7 +1838,103 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "id": 64,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "nim_gc_heap_instance_occupied_bytes{instance=~\"[[instance]]\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}  {{type_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Heap allocation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 4,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1895,193 +2006,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 68
-      },
-      "id": 64,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "nim_gc_heap_instance_occupied_bytes{instance=~\"[[instance]]\"}",
-          "interval": "",
-          "legendFormat": "{{instance}}  {{type_name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Heap allocation",
-      "type": "timeseries"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 76
-      },
-      "hiddenSeries": false,
-      "id": 4,
-      "legend": {
-        "alignAsTable": false,
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "9.2.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "expr": "sum by (instance)(process_virtual_memory_bytes{instance=~\"[[instance]]\"})",
-          "interval": "",
-          "legendFormat": "{{instance}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Virtual Memory",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:263",
-          "format": "decbytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:264",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -2102,7 +2026,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 70
       },
       "hiddenSeries": false,
       "id": 5,
@@ -2124,7 +2048,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2177,6 +2101,206 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (instance)(process_virtual_memory_bytes{instance=~\"[[instance]]\"})",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Virtual Memory",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:263",
+          "format": "decbytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:264",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "connected_peers{instance=~\"bridge*[[instance]]\"}",
+          "interval": "",
+          "legendFormat": "v1_connected_peers",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "libp2p_pubsub_peers{instance=~\"bridge*[[instance]]\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "v2_connected_peers",
+          "refId": "B"
+        }
+      ],
+      "title": "Connected Peers",
+      "type": "timeseries"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
@@ -2200,6 +2324,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2221,7 +2346,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2236,7 +2362,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 83
+        "y": 82
       },
       "id": 70,
       "options": {
@@ -2304,109 +2430,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 83
-      },
-      "id": 74,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "connected_peers{instance=~\"bridge*[[instance]]\"}",
-          "interval": "",
-          "legendFormat": "v1_connected_peers",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "libp2p_pubsub_peers{instance=~\"bridge*[[instance]]\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "v2_connected_peers",
-          "refId": "B"
-        }
-      ],
-      "title": "Connected Peers",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -2416,7 +2439,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 90
       },
       "id": 34,
       "panels": [],
@@ -2449,188 +2472,6 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 3,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 98
-      },
-      "id": 62,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "increase(waku_store_queries{instance=~\"nwaku_postgres:8003\"}[1m])",
-          "interval": "",
-          "legendFormat": "{{instance}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Waku Store Queries (Postgres) (1m rate)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 3,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 98
-      },
-      "id": 62,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "increase(waku_store_queries{instance=~\"nwaku_sqlite:8004\"}[1m])",
-          "interval": "",
-          "legendFormat": "{{instance}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Waku Store Queries (SQLite) (1m rate)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
@@ -2638,6 +2479,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2659,7 +2501,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2673,10 +2516,10 @@
       "gridPos": {
         "h": 6,
         "w": 12,
-        "x": 12,
-        "y": 98
+        "x": 0,
+        "y": 91
       },
-      "id": 40,
+      "id": 81,
       "options": {
         "legend": {
           "calcs": [],
@@ -2697,101 +2540,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (type)(increase(waku_archive_errors{instance=~\"nwaku_postgres:8003\"}[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{type}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Waku Archive Errors (Postgres) (1m rate)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 98
-      },
-      "id": 40,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum by (type)(increase(waku_archive_errors{instance=~\"nwaku_sqlite:8004\"}[1m]))",
+          "expr": "sum by (type)(increase(waku_archive_errors{instance=~\"nwaku-sqlite:8004\"}[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{type}}",
@@ -2803,88 +2552,82 @@
       "type": "timeseries"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateRdYlGn",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 12,
-        "x": 0,
-        "y": 104
+        "x": 12,
+        "y": 91
       },
-      "heatmap": {},
-      "hideZeroBuckets": true,
-      "highlightCards": true,
-      "id": 77,
-      "legend": {
-        "show": false
-      },
-      "maxDataPoints": 60,
+      "id": 40,
       "options": {
-        "calculate": false,
-        "calculation": {},
-        "cellGap": 2,
-        "cellValues": {},
-        "color": {
-          "exponent": 0.5,
-          "fill": "#b4ff00",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "RdYlGn",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
         "legend": {
-          "show": false
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "showValue": "never",
         "tooltip": {
-          "show": true,
-          "yHistogram": true
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "decimals": 0,
-          "reverse": false,
-          "unit": "s"
+          "mode": "single",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.2.5",
-      "reverseYBuckets": false,
       "targets": [
         {
           "datasource": {
@@ -2892,43 +2635,17 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(increase(waku_archive_query_duration_seconds_bucket{instance=~\"nwaku_postgres:8003\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
+          "exemplar": true,
+          "expr": "sum by (type)(increase(waku_archive_errors{instance=~\"nwaku-postgres:8003\"}[1m]))",
           "hide": false,
-          "legendFormat": "{{le}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(waku_store_query_duration_seconds_bucket{instance=~\"nwaku_postgres:8003\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "hide": true,
-          "legendFormat": "{{le}}",
+          "interval": "",
+          "legendFormat": "{{type}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Waku Archive Query Duration (Postgres)",
-      "tooltip": {
-        "show": true,
-        "showHistogram": true
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "decimals": 0,
-        "format": "s",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
+      "title": "Waku Archive Errors (Postgres) (1m rate)",
+      "type": "timeseries"
     },
     {
       "cards": {},
@@ -2963,12 +2680,12 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 104
+        "y": 97
       },
       "heatmap": {},
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 77,
+      "id": 75,
       "legend": {
         "show": false
       },
@@ -3011,7 +2728,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -3020,28 +2737,18 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(increase(waku_archive_query_duration_seconds_bucket{instance=~\"nwaku_sqlite:8004\"}[$__rate_interval])) by (le)",
+          "exemplar": true,
+          "expr": "waku_archive_insert_duration_seconds_bucket{instance=~\"nwaku-sqlite:8004\"}",
           "format": "heatmap",
           "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
           "legendFormat": "{{le}}",
-          "range": true,
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(waku_store_query_duration_seconds_bucket{instance=~\"nwaku_sqlite:8004\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "hide": true,
-          "legendFormat": "{{le}}",
-          "range": true,
-          "refId": "A"
         }
       ],
-      "title": "Waku Archive Query Duration (SQLite)",
+      "title": "Insert Duration (SQLite)",
       "tooltip": {
         "show": true,
         "showHistogram": true
@@ -3091,12 +2798,12 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 104
+        "y": 97
       },
       "heatmap": {},
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 75,
+      "id": 83,
       "legend": {
         "show": false
       },
@@ -3139,7 +2846,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -3149,7 +2856,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(waku_archive_insert_duration_seconds_bucket{instance=~\"nwaku_postgres:8003\"}[$__rate_interval])) by (le)",
+          "expr": "waku_archive_insert_duration_seconds_bucket{instance=~\"nwaku-postgres:8003\"}",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -3157,25 +2864,254 @@
           "intervalFactor": 1,
           "legendFormat": "{{le}}",
           "refId": "B"
+        }
+      ],
+      "title": "Insert Duration (Postgres)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "decimals": 0,
+        "format": "s",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 104
+      },
+      "id": 85,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(increase(waku_store_insert_duration_seconds_bucket{instance=~\"nwaku_postgres:8003\"}[$__rate_interval])) by (le)",
+          "exemplar": false,
+          "expr": "(rate(waku_archive_insert_duration_seconds_bucket{instance=~\"nwaku-sqlite:8004\"}[$__range])/scalar(rate(waku_archive_insert_duration_seconds_count{instance=~\"nwaku-sqlite:8004\"}[$__range])))*100",
           "format": "heatmap",
-          "hide": true,
           "instant": false,
           "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{le}}",
+          "legendFormat": "{{label_name}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Waku Archive Insert Duration (Postgres)",
+      "title": "Insert Time Distribution SQLite (% ms)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 104
+      },
+      "id": 84,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "(rate(waku_archive_insert_duration_seconds_bucket{instance=~\"nwaku-postgres:8003\"}[$__range])/scalar(rate(waku_archive_insert_duration_seconds_count{instance=~\"nwaku-postgres:8003\"}[$__range])))*100",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "{{label_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Insert Time Distribution Postgres (% ms)",
+      "type": "bargauge"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateRdYlGn",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 112
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 82,
+      "legend": {
+        "show": false
+      },
+      "maxDataPoints": 60,
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 0,
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "10.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "waku_archive_query_duration_seconds_bucket{instance=~\"nwaku-sqlite:8004\"}",
+          "format": "heatmap",
+          "hide": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Query Duration (SQLite)",
       "tooltip": {
         "show": true,
         "showHistogram": true
@@ -3225,12 +3161,12 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 104
+        "y": 112
       },
       "heatmap": {},
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 75,
+      "id": 77,
       "legend": {
         "show": false
       },
@@ -3273,7 +3209,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.2.5",
+      "pluginVersion": "10.1.5",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -3282,34 +3218,15 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(increase(waku_archive_insert_duration_seconds_bucket{instance=~\"nwaku_sqlite:8004\"}[$__rate_interval])) by (le)",
+          "expr": "waku_archive_query_duration_seconds_bucket{instance=~\"nwaku-postgres:8003\"}",
           "format": "heatmap",
           "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
           "legendFormat": "{{le}}",
+          "range": true,
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(increase(waku_store_insert_duration_seconds_bucket{instance=~\"nwaku_sqlite:8004\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "hide": true,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{le}}",
-          "refId": "A"
         }
       ],
-      "title": "Waku Archive Insert Duration (SQLite)",
+      "title": "Query Duration (Postgres)",
       "tooltip": {
         "show": true,
         "showHistogram": true
@@ -3325,19 +3242,388 @@
         "show": true
       },
       "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 119
+      },
+      "id": 88,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "(rate(waku_archive_query_duration_seconds_bucket{instance=~\"nwaku-sqlite:8004\"}[$__range])/scalar(rate(waku_archive_query_duration_seconds_count{instance=~\"nwaku-sqlite:8004\"}[$__range])))*100",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "{{label_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Query Time Distribution SQLite (% ms)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 119
+      },
+      "id": 89,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "(rate(waku_archive_query_duration_seconds_bucket{instance=~\"nwaku-postgres:8003\"}[$__range])/scalar(rate(waku_archive_query_duration_seconds_count{instance=~\"nwaku-postgres:8003\"}[$__range])))*100",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "{{label_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Query Time Distribution Postgres (% ms)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 3,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 127
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "increase(waku_store_queries{instance=~\"nwaku-postgres:8003\"}[1m])",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "increase(waku_store_queries{instance=~\"nwaku-sqlite:8004\"}[1m])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Waku Store Queries (1m rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 3,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "nwaku-postgres:8003"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 127
+      },
+      "id": 87,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "increase(waku_archive_insert_duration_seconds_count{instance=~\"nwaku-postgres:8003\"}[1m])",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "increase(waku_archive_insert_duration_seconds_count{instance=~\"nwaku-sqlite:8004\"}[1m])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Waku Insert Queries (1m rate)",
+      "type": "timeseries"
     }
   ],
-  "refresh": "5s",
-  "schemaVersion": 37,
+  "refresh": "10s",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "nwaku_.*",
-          "value": "nwaku_.*"
+          "selected": true,
+          "text": "nwaku-postgres",
+          "value": "nwaku-postgres:8003"
         },
         "hide": 0,
         "includeAll": false,
@@ -3347,17 +3633,17 @@
         "options": [
           {
             "selected": true,
-            "text": "nwaku_postgres",
-            "value": "nwaku_postgres:8003"
+            "text": "nwaku-postgres",
+            "value": "nwaku-postgres:8003"
           },
           {
-            "selected": true,
-            "text": "nwaku_sqlite",
-            "value": "nwaku_sqlite:8004"
+            "selected": false,
+            "text": "nwaku-sqlite",
+            "value": "nwaku-sqlite:8004"
           }
         ],
-        "query": "nwaku_.*",
-        "queryValue": "nwaku_.*",
+        "query": "nwaku-.*",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       }
@@ -3383,6 +3669,6 @@
   "timezone": "browser",
   "title": "Waku Analysis",
   "uid": "qrp_ZCTGz",
-  "version": 104,
+  "version": 2,
   "weekStart": ""
 }

--- a/docker/monitoring/prometheus-config.yml
+++ b/docker/monitoring/prometheus-config.yml
@@ -7,11 +7,11 @@ global:
 scrape_configs:
   - job_name: "nwaku_postgres"
     static_configs:
-    - targets: ['nwaku_postgres:8003']
+    - targets: ['nwaku-postgres:8003']
 
   - job_name: "nwaku_sqlite"
     static_configs:
-    - targets: ['nwaku_sqlite:8004']
+    - targets: ['nwaku-sqlite:8004']
 
   - job_name: postgres-exporter
     static_configs:

--- a/docker/postgres_cfg/postgresql.conf
+++ b/docker/postgres_cfg/postgresql.conf
@@ -63,7 +63,7 @@ listen_addresses = '*'
 					# (change requires restart)
 #port = 5432				# (change requires restart)
 max_connections = 100			# (change requires restart)
-#superuser_reserved_connections = 3	# (change requires restart)
+superuser_reserved_connections = 3	# (change requires restart)
 #unix_socket_directories = '/var/run/postgresql'	# comma-separated list of directories
 					# (change requires restart)
 #unix_socket_group = ''			# (change requires restart)
@@ -124,9 +124,9 @@ max_connections = 100			# (change requires restart)
 
 # - Memory -
 
-shared_buffers = 128MB			# min 128kB
+shared_buffers = 512MB			# min 128kB
 					# (change requires restart)
-#huge_pages = try			# on, off, or try
+huge_pages = off			# on, off, or try
 					# (change requires restart)
 #huge_page_size = 0			# zero for system default
 					# (change requires restart)
@@ -135,9 +135,9 @@ shared_buffers = 128MB			# min 128kB
 					# (change requires restart)
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
-#work_mem = 4MB				# min 64kB
+work_mem = 32MB				# min 64kB
 #hash_mem_multiplier = 2.0		# 1-1000.0 multiplier on hash table work_mem
-#maintenance_work_mem = 64MB		# min 1MB
+maintenance_work_mem = 320MB		# min 1MB
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #logical_decoding_work_mem = 64MB	# min 64kB
 #max_stack_depth = 2MB			# min 100kB
@@ -176,22 +176,22 @@ dynamic_shared_memory_type = posix	# the default is usually the first option
 
 # - Background Writer -
 
-#bgwriter_delay = 200ms			# 10-10000ms between rounds
-#bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
-#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
-#bgwriter_flush_after = 512kB		# measured in pages, 0 disables
+bgwriter_delay = 200ms			# 10-10000ms between rounds
+bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
+bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+bgwriter_flush_after = 0		# measured in pages, 0 disables
 
 # - Asynchronous Behavior -
 
 #backend_flush_after = 0		# measured in pages, 0 disables
-#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+effective_io_concurrency = 100		# 1-1000; 0 disables prefetching
 #maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
-#max_worker_processes = 8		# (change requires restart)
-#max_parallel_workers_per_gather = 2	# taken from max_parallel_workers
-#max_parallel_maintenance_workers = 2	# taken from max_parallel_workers
-#max_parallel_workers = 8		# maximum number of max_worker_processes that
+max_worker_processes = 1		# (change requires restart)
+max_parallel_workers_per_gather = 1	# taken from max_parallel_workers
+max_parallel_maintenance_workers = 1	# taken from max_parallel_workers
+max_parallel_workers = 1		# maximum number of max_worker_processes that
 					# can be used in parallel operations
-#parallel_leader_participation = on
+parallel_leader_participation = on
 #old_snapshot_threshold = -1		# 1min-60d; -1 disables; 0 is immediate
 					# (change requires restart)
 
@@ -223,7 +223,7 @@ dynamic_shared_memory_type = posix	# the default is usually the first option
 					# off, pglz, lz4, zstd, or on
 #wal_init_zero = on			# zero-fill new WAL files
 #wal_recycle = on			# recycle WAL files
-#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
 					# (change requires restart)
 #wal_writer_delay = 200ms		# 1-10000 milliseconds
 #wal_writer_flush_after = 1MB		# measured in pages, 0 disables
@@ -235,11 +235,11 @@ dynamic_shared_memory_type = posix	# the default is usually the first option
 # - Checkpoints -
 
 #checkpoint_timeout = 5min		# range 30s-1d
-#checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
+checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_flush_after = 256kB		# measured in pages, 0 disables
 #checkpoint_warning = 30s		# 0 disables
-max_wal_size = 1GB
-min_wal_size = 80MB
+max_wal_size = 1024MB
+min_wal_size = 512MB
 
 # - Prefetching during recovery -
 
@@ -392,7 +392,7 @@ min_wal_size = 80MB
 # - Planner Cost Constants -
 
 #seq_page_cost = 1.0			# measured on an arbitrary scale
-#random_page_cost = 4.0			# same scale as above
+random_page_cost = 1.25			# same scale as above
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005		# same scale as above
 #cpu_operator_cost = 0.0025		# same scale as above
@@ -400,7 +400,7 @@ min_wal_size = 80MB
 #parallel_tuple_cost = 0.1		# same scale as above
 #min_parallel_table_scan_size = 8MB
 #min_parallel_index_scan_size = 512kB
-#effective_cache_size = 4GB
+effective_cache_size = 1GB
 
 #jit_above_cost = 100000		# perform JIT compilation if available
 					# and query more expensive than this;
@@ -423,7 +423,7 @@ min_wal_size = 80MB
 
 # - Other Planner Options -
 
-#default_statistics_target = 100	# range 1-10000
+default_statistics_target = 500	# range 1-10000
 #constraint_exclusion = partition	# on, off, or partition
 #cursor_tuple_fraction = 0.1		# range 0.0-1.0
 #from_collapse_limit = 8
@@ -514,7 +514,7 @@ min_wal_size = 80MB
 					#   fatal
 					#   panic (effectively off)
 
-#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+log_min_duration_statement = 11	# -1 is disabled, 0 logs all statements
 					# and their durations, > 0 logs only
 					# statements running at least this number
 					# of milliseconds

--- a/docker/run_bootstrap.sh
+++ b/docker/run_bootstrap.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+IP=$(ip a | grep "inet " | grep -Fv 127.0.0.1 | sed 's/.*inet \([^/]*\).*/\1/')
+
+echo "I am a bootstrap node. Listening to: ${IP}"
+
+exec /usr/bin/wakunode\
+      --relay=true\
+      --rpc-admin=true\
+      --keep-alive=true\
+      --max-connections=300\
+      --dns-discovery=true\
+      --discv5-discovery=true\
+      --discv5-enr-auto-update=True\
+      --log-level=INFO\
+      --rpc-port=8544\
+      --rpc-address=0.0.0.0\
+      --metrics-server=True\
+      --metrics-server-address=0.0.0.0\
+      --nodekey=30348dd51465150e04a5d9d932c72864c8967f806cce60b5d26afeca1e77eb68\
+      --nat=extip:${IP}

--- a/docker/run_nwaku_store_postgres.sh
+++ b/docker/run_nwaku_store_postgres.sh
@@ -13,7 +13,7 @@ exec /usr/bin/wakunode\
   --topic=/waku/2/dev-waku/proto\
   --rpc-admin=true\
   --keep-alive=true\
-  --log-level=ERROR\
+  --log-level=DEBUG\
   --rpc-port=8545\
   --rpc-address=0.0.0.0\
   --tcp-port=30303\

--- a/docker/run_nwaku_store_postgres_ubuntu.sh
+++ b/docker/run_nwaku_store_postgres_ubuntu.sh
@@ -3,16 +3,32 @@
 apt-get update
 ## Install the `dig` command
 apt-get install dnsutils -y
+apt-get install wget -y
 
-peer_IP=$(dig +short nwaku_sqlite)
+bootstrap_IP=$(dig +short bootstrap)
 
 apt-get install libpq5 -y
-
 chmod +x /usr/bin/wakunode
 
+RETRIES=${RETRIES:=10}
+
+while [ -z "${BOOTSTRAP_ENR}" ] && [ ${RETRIES} -ge 0 ]; do
+  BOOTSTRAP_ENR=$(wget -O - --post-data='{"jsonrpc":"2.0","method":"get_waku_v2_debug_v1_info","params":[],"id":1}' --header='Content-Type:application/json' http://${bootstrap_IP}:8544/ 2> /dev/null | sed 's/.*"enrUri":"\([^"]*\)".*/\1/');
+  echo "Bootstrap node not ready in ${bootstrap_IP}, retrying (retries left: ${RETRIES})"
+  sleep 1
+  RETRIES=$(( $RETRIES - 1 ))
+done
+
+if [ -z "${BOOTSTRAP_ENR}" ]; then
+   echo "Could not get BOOTSTRAP_ENR and none provided. Failing"
+   exit 1
+fi
+
+IP=$(hostname -I)
+
+echo "I am postgres ubuntu. Listening on: ${IP}"
+
 ./usr/bin/wakunode\
-  --nodekey=1d714a1fada214dead6dc9c7274585eca0ff292451866e7d6d677dc818e8ccd2\
-  --staticnode=/ip4/${peer_IP}/tcp/30304/p2p/16Uiu2HAkxj3WzLiqBximSaHc8wV9Co87GyRGRYLVGsHZrzi3TL5W\
   --relay=true\
   --topic=/waku/2/default-waku/proto\
   --topic=/waku/2/dev-waku/proto\
@@ -21,10 +37,15 @@ chmod +x /usr/bin/wakunode
   --log-level=DEBUG\
   --rpc-port=8545\
   --rpc-address=0.0.0.0\
-  --tcp-port=30303\
   --metrics-server=True\
   --metrics-server-port=8003\
   --metrics-server-address=0.0.0.0\
+  --max-connections=250\
+  --dns-discovery=true\
+  --discv5-discovery=true\
+  --discv5-enr-auto-update=True\
+  --discv5-bootstrap-node=${BOOTSTRAP_ENR}\
+  --nat=extip:${IP}\
   --store-message-db-url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/postgres"\
   --store=true\
   --store-message-retention-policy=capacity:4000000

--- a/docker/run_nwaku_store_postgres_ubuntu.sh
+++ b/docker/run_nwaku_store_postgres_ubuntu.sh
@@ -48,4 +48,4 @@ echo "I am postgres ubuntu. Listening on: ${IP}"
   --nat=extip:${IP}\
   --store-message-db-url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/postgres"\
   --store=true\
-  --store-message-retention-policy=capacity:4000000
+  --store-message-retention-policy=capacity:12000000

--- a/docker/run_nwaku_store_sqlite.sh
+++ b/docker/run_nwaku_store_sqlite.sh
@@ -13,7 +13,7 @@ exec /usr/bin/wakunode\
   --topic=/waku/2/dev-waku/proto\
   --rpc-admin=true\
   --keep-alive=true\
-  --log-level=ERROR\
+  --log-level=DEBUG\
   --rpc-port=8546\
   --rpc-address=0.0.0.0\
   --tcp-port=30304\

--- a/docker/run_nwaku_store_sqlite_ubuntu.sh
+++ b/docker/run_nwaku_store_sqlite_ubuntu.sh
@@ -48,4 +48,4 @@ echo "I am sqlite ubuntu. Listening on: ${IP}"
   --nat=extip:${IP}\
   --store-message-db-url="sqlite:///data/store.sqlite3"\
   --store=true\
-  --store-message-retention-policy=capacity:4000000
+  --store-message-retention-policy=capacity:12000000

--- a/docker/run_waku_store_query_maker.sh
+++ b/docker/run_waku_store_query_maker.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+IP=$(ip a | grep "inet " | grep -Fv 127.0.0.1 | sed 's/.*inet \([^/]*\).*/\1/')
+
+echo "I am a waku store query generator"
+
+## Getting the address of the Postgres node
+RETRIES=10
+while [ -z "${POSTGRES_ADDR}" ] && [ ${RETRIES} -ge 0 ]; do
+  POSTGRES_ADDR=$(wget -O - --post-data='{"jsonrpc":"2.0","method":"get_waku_v2_debug_v1_info","params":[],"id":1}' --header='Content-Type:application/json' http://nwaku-postgres:8545/ 2> /dev/null | sed 's/.*"listenAddresses":\["\(.*\)"].*/\1/');
+  wget -O - --post-data='{"jsonrpc":"2.0","method":"get_waku_v2_debug_v1_info","params":[],"id":1}' --header='Content-Type:application/json' http://nwaku-postgres:8545/
+  echo "Store Postgres node node not ready, retrying (retries left: ${RETRIES})"
+  sleep 1
+  RETRIES=$(( $RETRIES - 1 ))
+done
+
+if [ -z "${POSTGRES_ADDR}" ]; then
+   echo "Could not get POSTGRES_ADDR and none provided. Failing"
+   exit 1
+fi
+
+## Getting the address of the SQLite node
+RETRIES=10
+while [ -z "${SQLITE_ADDR}" ] && [ ${RETRIES} -ge 0 ]; do
+  SQLITE_ADDR=$(wget -O - --post-data='{"jsonrpc":"2.0","method":"get_waku_v2_debug_v1_info","params":[],"id":1}' --header='Content-Type:application/json' http://nwaku-sqlite:8546/ 2> /dev/null | sed 's/.*"listenAddresses":\["\(.*\)"].*/\1/');
+  echo "Store SQLite node node not ready, retrying (retries left: ${RETRIES})"
+  sleep 1
+  RETRIES=$(( $RETRIES - 1 ))
+done
+
+if [ -z "${SQLITE_ADDR}" ]; then
+   echo "Could not get SQLITE_ADDR and none provided. Failing"
+   exit 1
+fi
+
+## Getting the bootstrap node ENR
+RETRIES=10
+while [ -z "${BOOTSTRAP_ENR}" ] && [ ${RETRIES} -ge 0 ]; do
+  BOOTSTRAP_ENR=$(wget -O - --post-data='{"jsonrpc":"2.0","method":"get_waku_v2_debug_v1_info","params":[],"id":1}' --header='Content-Type:application/json' http://bootstrap:8544/ 2> /dev/null | sed 's/.*"enrUri":"\([^"]*\)".*/\1/');
+  echo "Bootstrap node not ready, retrying (retries left: ${RETRIES})"
+  sleep 1
+  RETRIES=$(( $RETRIES - 1 ))
+done
+
+if [ -z "${BOOTSTRAP_ENR}" ]; then
+   echo "Could not get BOOTSTRAP_ENR and none provided. Failing"
+   exit 1
+fi
+
+echo "Using bootstrap node: ${BOOTSTRAP_ENR}"
+exec /main\
+    --pubsub-topic="/waku/2/default-waku/proto"\
+    --content-topic="my-ctopic"\
+    --queries-per-second=${STORE_QUERIES_PER_SECOND}\
+    --bootstrap-node=${BOOTSTRAP_ENR}\
+    --peer-store-postgres-addr="${POSTGRES_ADDR}"\
+    --peer-store-sqlite-addr="${SQLITE_ADDR}"\
+    --num-minutes-query=60

--- a/docker/run_waku_store_query_maker.sh
+++ b/docker/run_waku_store_query_maker.sh
@@ -47,6 +47,9 @@ if [ -z "${BOOTSTRAP_ENR}" ]; then
    exit 1
 fi
 
+## Further parameter details:
+#     --num-minutes-query -> to indicate the time window in the query. storedAt field.
+
 echo "Using bootstrap node: ${BOOTSTRAP_ENR}"
 exec /main\
     --pubsub-topic="/waku/2/default-waku/proto"\
@@ -55,4 +58,5 @@ exec /main\
     --bootstrap-node=${BOOTSTRAP_ENR}\
     --peer-store-postgres-addr="${POSTGRES_ADDR}"\
     --peer-store-sqlite-addr="${SQLITE_ADDR}"\
-    --num-minutes-query=60
+    --num-minutes-query=60\
+    --num-concurrent-users=1

--- a/docker/run_wakupublisher.sh
+++ b/docker/run_wakupublisher.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+IP=$(ip a | grep "inet " | grep -Fv 127.0.0.1 | sed 's/.*inet \([^/]*\).*/\1/')
+
+echo "I am a traffic generator"
+
+RETRIES=${RETRIES:=10}
+
+while [ -z "${BOOTSTRAP_ENR}" ] && [ ${RETRIES} -ge 0 ]; do
+  BOOTSTRAP_ENR=$(wget -O - --post-data='{"jsonrpc":"2.0","method":"get_waku_v2_debug_v1_info","params":[],"id":1}' --header='Content-Type:application/json' http://bootstrap:8544/ 2> /dev/null | sed 's/.*"enrUri":"\([^"]*\)".*/\1/');
+  echo "Bootstrap node not ready, retrying (retries left: ${RETRIES})"
+  sleep 1
+  RETRIES=$(( $RETRIES - 1 ))
+done
+
+if [ -z "${BOOTSTRAP_ENR}" ]; then
+   echo "Could not get BOOTSTRAP_ENR and none provided. Failing"
+   exit 1
+fi
+
+echo "Using bootstrap node: ${BOOTSTRAP_ENR}"
+exec /main\
+    --pubsub-topic="/waku/2/default-waku/proto"\
+    --content-topic="my-ctopic"\
+    --msg-per-second=${MSG_PER_SECOND}\
+    --msg-size-kb=${MSG_SIZE_KBYTES}\
+    --bootstrap-node=${BOOTSTRAP_ENR}\
+    --max-peers=50


### PR DESCRIPTION
- New `docker/docker-compose-manual-binaries.yml`
   - Allows to start `nwaku` docker containers but having a `wakunode2` binary that had been recently being compiled. This approach is interesting for debugging purposes where we can add more logs to debug waku archive timings, for instance.
   - We stress the `nwaku` nodes thanks to a couple of `go-waku` nodes: one that generates "inserts" to the databases (publishes relay messages,) and another that performs periodic _Store_ requests.
   - A bootstrap node is being used to establish the network.
- Updating image versions in `docker/docker-compose.yml` and exposing ports. This docker-compose file is mostly thought to be used in combination with `jmeter`.
- `docker/monitoring/configuration/dashboards/waku-analysis.json` - Enhancing the dashboard where we can compare easily the performance betwee _Posgres_ and _SQLite_.
- Enhancing the `docker/msg_publisher.sh` script that sends random messages around 10KB. Notice that this script is not used in the "manual" docker-compose.
- `go/main_test.go` & `sh/publish_one_client.sh` - sorry I unintentionally introduced those changes.

-------

Notice that with the changes introducted in the Grafana dashboard, we can have a better insight re the performance comparison between _SQLite_ and _Postgres_:
![image](https://github.com/waku-org/test-waku-query/assets/128452529/e809bdcd-588c-4e1d-98c0-15a2e9b336a9)

In the above image, we can see that the "Store" requests are performing much slower in _Postgres_ than in _SQLite_. Something to be studied carefully.