### PR TITLE
Multiple Waku nodes against one single PostgreSQL database

### DIFF
--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -115,8 +115,6 @@ services:
     ## This service is aimed to mimick other nodes interacting with the same database
     image: alpine:3.16
     restart: on-failure
-    logging:
-      driver: "none"
     volumes:
       - ./run_database_hammer.sh:/opt/run_database_hammer.sh:Z
     entrypoint: sh

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -41,7 +41,7 @@ services:
 
   bootstrap:
     image: statusteam/nim-waku:v0.20.0
-    restart: on-failure
+    restart: always
     ports:
       - 127.0.0.1:60000:60000
       - 127.0.0.1:8008:8008
@@ -67,6 +67,7 @@ services:
     ports:
       - 0.0.0.0:8546:8546
       - 0.0.0.0:8004:8004
+      - 0.0.0.0:60001:60001
     <<:
       - *logging
     volumes:
@@ -94,6 +95,7 @@ services:
     ports:
       - 0.0.0.0:8545:8545
       - 0.0.0.0:8003:8003
+      - 0.0.0.0:60002:60002
     <<:
       - *logging
       - *pg_env
@@ -134,7 +136,7 @@ services:
       - bootstrap
     deploy:
       mode: replicated
-      replicas: 10
+      replicas: 2
       resources:
         limits:
           cpus: '1'
@@ -153,7 +155,9 @@ services:
       driver: none
     deploy:
       mode: replicated
-      replicas: 10
+        #replicas: 0 - with this, normal behaviour
+        #replicas: 25 - it worked pretty well
+      replicas: 50
     command:
       - /opt/run_database_hammer.sh
     depends_on:
@@ -170,7 +174,7 @@ services:
       - ./run_waku_store_query_maker.sh:/opt/run_waku_store_query_maker.sh:Z
     environment:
       STORE_QUERIES_PER_SECOND: 1
-      NUM_CONCURRENT_USERS: 1
+      NUM_CONCURRENT_USERS: 25
     depends_on:
       - nwaku-postgres
       - nwaku-sqlite

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -114,7 +114,7 @@ services:
 
   nwaku-postgres-additional:
     ## Waku node with Store mounted & Postgres
-    ## This is aimed to produce more more insert operation to the same Potsgres database.
+    ## This is aimed to produce more insert operation to the same Potsgres database.
     image: ubuntu
     restart: on-failure
     <<:

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -120,12 +120,15 @@ services:
     volumes:
       - ./run_database_hammer.sh:/opt/run_database_hammer.sh:Z
     entrypoint: sh
-    replicas: 3
+    deploy:
+      mode: replicated
+      replicas: 1
     command:
       - /opt/run_database_hammer.sh
     depends_on:
-      - nwaku_postgres
-      - nwaku_sqlite
+      - postgres
+    networks:
+      - simulation
 
   waku-store-query-generator:
     image: ivansete/waku-store-request-maker:19e645

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -86,6 +86,7 @@ services:
 
   nwaku-postgres:
     ## Waku node with Store mounted & Postgres
+    ## It can be analyzed the metrics of this particular node
     image: ubuntu
     restart: on-failure
     ports:
@@ -111,8 +112,35 @@ services:
     networks:
       - simulation
 
+  nwaku-postgres-additional:
+    ## Waku node with Store mounted & Postgres
+    ## This is aimed to produce more more insert operation to the same Potsgres database.
+    image: ubuntu
+    restart: on-failure
+    <<:
+      - *logging
+      - *pg_env
+    volumes:
+    # This is expected to be run from metal-01.he-eu-hel1.wakudev.misc.statusim.net
+      - /home/shared/nwaku/build/wakunode2:/usr/bin/wakunode:Z
+      - ./run_nwaku_store_postgres_ubuntu.sh:/opt/run_nwaku_store_postgres_ubuntu.sh:Z
+    entrypoint: bash
+    command:
+      - /opt/run_nwaku_store_postgres_ubuntu.sh
+    depends_on:
+      - postgres
+    deploy:
+      mode: replicated
+      replicas: 10
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2048M
+    networks:
+      - simulation
+
   db-postgres-hammer:
-    ## This service is aimed to mimick other nodes interacting with the same database
+    ## This service is aimed to stress the database by performing simple select queries
     image: alpine:3.16
     restart: on-failure
     volumes:
@@ -120,7 +148,7 @@ services:
     entrypoint: sh
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 10
     command:
       - /opt/run_database_hammer.sh
     depends_on:

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -76,6 +76,8 @@ services:
     entrypoint: sh
     command:
       - /opt/run_nwaku_store_sqlite.sh
+    depends_on:
+      - bootstrap
     deploy:
       resources:
         limits:
@@ -104,6 +106,7 @@ services:
       - /opt/run_nwaku_store_postgres_ubuntu.sh
     depends_on:
       - postgres
+      - bootstrap
     deploy:
       resources:
         limits:
@@ -128,7 +131,7 @@ services:
     command:
       - /opt/run_nwaku_store_postgres_ubuntu.sh
     depends_on:
-      - postgres
+      - bootstrap
     deploy:
       mode: replicated
       replicas: 10
@@ -166,6 +169,9 @@ services:
     environment:
       STORE_QUERIES_PER_SECOND: 1
       NUM_CONCURRENT_USERS: 1
+    depends_on:
+      - nwaku-postgres
+      - nwaku-sqlite
     networks:
       - simulation
 
@@ -179,6 +185,7 @@ services:
       MSG_PER_SECOND: 10
       MSG_SIZE_KBYTES: 10
     depends_on:
+      - bootstrap
       - nwaku-postgres
       - nwaku-sqlite
     networks:

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -111,6 +111,22 @@ services:
     networks:
       - simulation
 
+  db-postgres-hammer:
+    ## This service is aimed to mimick other nodes interacting with the same database
+    image: alpine:3.16
+    restart: on-failure
+    logging:
+      driver: "none"
+    volumes:
+      - ./run_database_hammer.sh:/opt/run_database_hammer.sh:Z
+    entrypoint: sh
+    replicas: 3
+    command:
+      - /opt/run_database_hammer.sh
+    depends_on:
+      - nwaku_postgres
+      - nwaku_sqlite
+
   waku-store-query-generator:
     image: ivansete/waku-store-request-maker:19e645
     restart: on-failure

--- a/docker/docker-compose-manual-binaries.yml
+++ b/docker/docker-compose-manual-binaries.yml
@@ -149,6 +149,8 @@ services:
     volumes:
       - ./run_database_hammer.sh:/opt/run_database_hammer.sh:Z
     entrypoint: sh
+    logging:
+      driver: none
     deploy:
       mode: replicated
       replicas: 10

--- a/docker/run_bootstrap.sh
+++ b/docker/run_bootstrap.sh
@@ -20,7 +20,7 @@ exec /usr/bin/wakunode\
       --dns-discovery=true\
       --discv5-discovery=true\
       --discv5-enr-auto-update=True\
-      --log-level=INFO\
+      --log-level=DEBUG\
       --rpc-port=8544\
       --rpc-address=0.0.0.0\
       --metrics-server=True\

--- a/docker/run_database_hammer.sh
+++ b/docker/run_database_hammer.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+## This script is aimed to generate traffic to the database and simulate
+## simulate multiple Waku nodes connected to the same database.
+
+## Install the `dig` command
+apk --no-cache add bind-tools
+
+## Install postgresql-client for psql command
+apk --no-cache add postgresql-client
+
+## The port numbers and host names are defined in the 'docker-compose.yml' file
+nwaku-postgres-IP=$(dig +short postgres)
+target-postgres="http://${nwaku-postgres-IP}:5432"
+
+echo "This is publisher: ${target-postgres}; ${target_sqlite}"
+
+query-last-five-minutes="SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages WHERE storedAt >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '5 minutes')) * 1000 ORDER BY storedAt DESC;"
+while true
+do
+  echo "Before making query"
+  psql -h ${nwaku-postgres-IP} -U postgres -W test123 -U postgres -c "${query-last-five-minutes}"
+
+  sleep 10
+done

--- a/docker/run_database_hammer.sh
+++ b/docker/run_database_hammer.sh
@@ -18,5 +18,5 @@ do
   echo "Before making query"
   psql -h postgres -p 5432 -U postgres -U postgres -w -c "${QUERY_LAST_FIVE_MINUTES}"
 
-  sleep 10
+  #sleep 0.01
 done

--- a/docker/run_database_hammer.sh
+++ b/docker/run_database_hammer.sh
@@ -18,5 +18,5 @@ do
   echo "Before making query"
   psql -h postgres -p 5432 -U postgres -U postgres -w -c "${QUERY_LAST_FIVE_MINUTES}"
 
-  #sleep 0.01
+  sleep 0.01
 done

--- a/docker/run_database_hammer.sh
+++ b/docker/run_database_hammer.sh
@@ -3,23 +3,20 @@
 ## This script is aimed to generate traffic to the database and simulate
 ## simulate multiple Waku nodes connected to the same database.
 
-## Install the `dig` command
-apk --no-cache add bind-tools
-
 ## Install postgresql-client for psql command
 apk --no-cache add postgresql-client
 
 ## The port numbers and host names are defined in the 'docker-compose.yml' file
-nwaku-postgres-IP=$(dig +short postgres)
-target-postgres="http://${nwaku-postgres-IP}:5432"
 
-echo "This is publisher: ${target-postgres}; ${target_sqlite}"
+echo "This is database hammer"
 
-query-last-five-minutes="SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages WHERE storedAt >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '5 minutes')) * 1000 ORDER BY storedAt DESC;"
+export PGPASSWORD=test123
+QUERY_LAST_FIVE_MINUTES=$(echo 'SELECT * FROM messages ORDER BY storedAt DESC LIMIT 100;')
+
 while true
 do
   echo "Before making query"
-  psql -h ${nwaku-postgres-IP} -U postgres -W test123 -U postgres -c "${query-last-five-minutes}"
+  psql -h postgres -p 5432 -U postgres -U postgres -w -c "${QUERY_LAST_FIVE_MINUTES}"
 
   sleep 10
 done

--- a/docker/run_nwaku_store_postgres_ubuntu.sh
+++ b/docker/run_nwaku_store_postgres_ubuntu.sh
@@ -8,7 +8,6 @@ apt-get install wget -y
 bootstrap_IP=$(dig +short bootstrap)
 
 apt-get install libpq5 -y
-chmod +x /usr/bin/wakunode
 
 RETRIES=${RETRIES:=10}
 
@@ -28,6 +27,7 @@ IP=$(hostname -I)
 
 echo "I am postgres ubuntu. Listening on: ${IP}"
 
+  ##--store-max-num-db-connections=50\
 ./usr/bin/wakunode\
   --relay=true\
   --topic=/waku/2/default-waku/proto\
@@ -36,6 +36,7 @@ echo "I am postgres ubuntu. Listening on: ${IP}"
   --keep-alive=true\
   --log-level=DEBUG\
   --rpc-port=8545\
+  --tcp-port=60002\
   --rpc-address=0.0.0.0\
   --metrics-server=True\
   --metrics-server-port=8003\

--- a/docker/run_nwaku_store_sqlite_ubuntu.sh
+++ b/docker/run_nwaku_store_sqlite_ubuntu.sh
@@ -8,7 +8,6 @@ apt-get install wget -y
 bootstrap_IP=$(dig +short bootstrap)
 
 apt-get install libpq5 -y
-chmod +x /usr/bin/wakunode
 
 RETRIES=${RETRIES:=10}
 
@@ -36,6 +35,7 @@ echo "I am sqlite ubuntu. Listening on: ${IP}"
   --keep-alive=true\
   --log-level=DEBUG\
   --rpc-port=8546\
+  --tcp-port=60001\
   --rpc-address=0.0.0.0\
   --metrics-server=True\
   --metrics-server-port=8004\


### PR DESCRIPTION
With this PR, we introduce two more possible containers that can participate in the simulations:

- nwaku-postgres-additional
This is merely a copy of the `nwaku-postgres` container and is aimed for introducing parallel inserts in the `postgres` database. I'm setting this as a separate container definition because if I want to keep only one `nwaku` node that will receive _Store_ requests and will also server as a node of reference/analysis.

- db-postgres-hammer
This is aimed for just performing parallel `select` queries to the _PostgreSQL_ database, and therefore stress the database. We have this as a separate container because that will bring more flexibility to specify how the queries are performed, and in which rate.